### PR TITLE
Si 8748 error handling

### DIFF
--- a/lib/features/photostock_list/presentation/photo_list_wm.dart
+++ b/lib/features/photostock_list/presentation/photo_list_wm.dart
@@ -89,6 +89,21 @@ final class PhotoListWM extends WidgetModel<PhotoListScreen, PhotoListModel>
   @override
   void initWidgetModel() {
     model.loadPhotos(page++);
+    _observerStateNewList();
     super.initWidgetModel();
+  }
+
+  void _observerStateNewList() {
+    stateNewList.addListener(() {
+      if (stateNewList.value is NewListStateError) {
+        _showErrorAppSnackBar();
+      }
+    });
+  }
+
+  void _showErrorAppSnackBar() {
+    _scaffoldMessenger.showSnackBar(
+      SnackBar(content: Text(l10n.photoListFailedLoadListPhotoMessage)),
+    );
   }
 }

--- a/lib/features/photostock_list/presentation/photo_list_wm.dart
+++ b/lib/features/photostock_list/presentation/photo_list_wm.dart
@@ -5,10 +5,10 @@ import 'package:flutter_template/common/mixin/localization_mixin.dart';
 import 'package:flutter_template/features/app/di/app_scope.dart';
 import 'package:flutter_template/features/common/utils/mixin/theme_wm_mixin.dart';
 import 'package:flutter_template/features/photostock_list/di/photo_list_scope.dart';
-import 'package:flutter_template/features/photostock_list/presentation/uploaded_list_state.dart';
 import 'package:flutter_template/features/photostock_list/presentation/photo_list_model.dart';
 import 'package:flutter_template/features/photostock_list/presentation/photo_list_screen.dart';
 import 'package:flutter_template/features/photostock_list/presentation/screen_list_state.dart';
+import 'package:flutter_template/features/photostock_list/presentation/uploaded_list_state.dart';
 import 'package:provider/provider.dart';
 
 /// DI factory for [PhotoListWM].
@@ -95,7 +95,7 @@ final class PhotoListWM extends WidgetModel<PhotoListScreen, PhotoListModel>
 
   void _observerStateNewList() {
     stateNewList.addListener(() {
-      if (stateNewList.value is NewListStateError) {
+      if (stateNewList.value is UploadedListStateError) {
         _showErrorAppSnackBar();
       }
     });


### PR DESCRIPTION
[SI-8748](https://jira.surf.dev/browse/SI-8748) error handling:
- added ScaffoldMessengerState _scaffoldMessenger for call showSnackBar;
- added func _showErrorAppSnackBar calling the showSnackBar;
- added func _observerStateNewList that listens for an error state.

If a download error occurs, a snackbar is displayed, reporting a download error.

<p align="center">
<img src="https://github.com/YaslikS/photostock/assets/58375980/03d067ad-6cb0-4e07-b939-664aa9e6c168" height="220" />

https://github.com/YaslikS/photostock/assets/58375980/d97aaec4-6c33-44a1-b64a-bc9fb8f60c3d
</p>



